### PR TITLE
Fix timing after reconnect

### DIFF
--- a/python/advanced_callback_example.py
+++ b/python/advanced_callback_example.py
@@ -7,17 +7,17 @@ use it like
 
 session_id = "not-set"
 
-def advanced_callback(asr_response):
+def advanced_callback(asr_response, correction = 0):
     print "Got response:"
     print "end-of-utterance = {}".format(asr_response.endOfUtt)
     r_count = 0
     for r in asr_response.recognition:
         print "recognition[{}] = {}; confidence = {}".format(r_count, r.normalized.encode("utf-8"), r.confidence)
-        print "utterance timings: from {} to {}".format(r.align_info.start_time,r.align_info.end_time)
+        print "utterance timings: from {} to {}".format(r.align_info.start_time+correction,r.align_info.end_time+correction)
         w_count = 0
         for w in r.words:
             print "word[{}] = {}; confidence = {}".format(w_count, w.value.encode("utf-8"), w.confidence)
-            print "word timings: from {} to {}".format(w.align_info.start_time,w.align_info.end_time)
+            print "word timings: from {} to {}".format(w.align_info.start_time+correction,w.align_info.end_time+correction)
             w_count += 1
         r_count += 1
 

--- a/python/advanced_callback_splitter.py
+++ b/python/advanced_callback_splitter.py
@@ -24,17 +24,17 @@ mkdir_p(start_timestamp)
 
 utterance_count = 0
 
-def advanced_callback(asr_response):
+def advanced_callback(asr_response, correction = 0):
     print "Got response:"
     print "end-of-utterance = {}".format(asr_response.endOfUtt)
     r_count = 0
     for r in asr_response.recognition:
         print "recognition[{}] = {}; confidence = {}".format(r_count, r.normalized.encode("utf-8"), r.confidence)
-        print "utterance timings: from {} to {}".format(r.align_info.start_time,r.align_info.end_time)
+        print "utterance timings: from {} to {}".format(r.align_info.start_time+correction,r.align_info.end_time+correction)
         w_count = 0
         for w in r.words:
             print "word[{}] = {}; confidence = {}".format(w_count, w.value.encode("utf-8"), w.confidence)
-            print "word timings: from {} to {}".format(w.align_info.start_time,w.align_info.end_time)
+            print "word timings: from {} to {}".format(w.align_info.start_time+correction,w.align_info.end_time+correction)
             w_count += 1
         r_count += 1
 


### PR DESCRIPTION
Если сервер рвет соединение, клиент переподключается и тайминг обнуляется.
Сохраняем последнее значение, что бы в дальнейшем тайминг скорректировать в advanced_callback(). Это не идеально, погрешность все равно будет, но это лучше, чем сейчас.