### PR TITLE
--disable-antimat-normalizer CLI option added

### DIFF
--- a/python/asrclient-cli.py
+++ b/python/asrclient-cli.py
@@ -107,6 +107,10 @@ except ImportError:
 @click.option('--grammar-file',
               default="",
               help='Custom grammar, can be list of lines or xml file description')
+click.option('--disable-antimat-normalizer',
+              default=False,
+              is_flag=True,
+              help='Swear words are not censored out.')
 def main(chunk_size, start_with_chunk, max_chunks_count, record, files, silent, **kwars):
     if not silent:
         logging.basicConfig(level=logging.INFO)

--- a/python/asrclient/client.py
+++ b/python/asrclient/client.py
@@ -82,7 +82,7 @@ class ServerError(RuntimeError):
 
 class ServerConnection(object):
 
-    def __init__(self, host, port, key, app, service, topic, lang, format, uuid, inter_utt_silence, cmn_latency, biometry, logger=None, punctuation=True, ipv4=False, capitalize=False, expected_num_count=0, snr=False, snr_flags=None, grammar_file=""):
+    def __init__(self, host, port, key, app, service, topic, lang, format, uuid, inter_utt_silence, cmn_latency, biometry, logger=None, punctuation=True, ipv4=False, capitalize=False, expected_num_count=0, snr=False, snr_flags=None, grammar_file="", disable_antimat_normalizer=False):
         self.host = host
         self.port = port
         self.key = key
@@ -101,6 +101,7 @@ class ServerConnection(object):
         self.capitalize = capitalize
         self.expected_num_count = expected_num_count
         self.snr = snr
+        self.disable_antimat_normalizer = disable_antimat_normalizer
         
         if not snr_flags:
             self.snr_flags = []
@@ -165,6 +166,7 @@ class ServerConnection(object):
             lang=self.lang,
             format=self.format,
             punctuation=self.punctuation,
+            disableAntimatNormalizer=self.disable_antimat_normalizer,
             advancedASROptions=advancedASROptions
         )
 
@@ -256,6 +258,7 @@ def recognize(chunks,
               expected_num_count=0,
               snr=False,
               snr_flags=None,
+              disable_antimat_normalizer=False,
               grammar_file=""):
 
     advanced_utterance_callback = None
@@ -279,7 +282,7 @@ def recognize(chunks,
         def __init__(self):
             self.logger = logging.getLogger('asrclient')
             
-            self.server = ServerConnection(server, port, key, app, service, model, lang, format, uuid, inter_utt_silence, cmn_latency, biometry, self.logger, not nopunctuation, ipv4, capitalize, expected_num_count, snr, snr_flags, grammar_file)
+            self.server = ServerConnection(server, port, key, app, service, model, lang, format, uuid, inter_utt_silence, cmn_latency, biometry, self.logger, not nopunctuation, ipv4, capitalize, expected_num_count, snr, snr_flags, grammar_file, disable_antimat_normalizer)
             self.unrecognized_chunks = []
             self.retry_count = 0
             self.pending_answers = 0


### PR DESCRIPTION
Пробросил параметр для возможности отключения цензуры ненормативной лексики. Наличие опции замечено в protobuf-классе `ConnectionRequest`.